### PR TITLE
Using "=" in SQL WHERE clause, instead of "=="

### DIFF
--- a/R/rmarkdown/best_customer.Rmd
+++ b/R/rmarkdown/best_customer.Rmd
@@ -9,7 +9,7 @@ params:
 branch <- params$branch
 
 statement <- glue::glue_sql("SELECT * from customers
-                             WHERE branch == {branch}", 
+                             WHERE branch = {branch}", 
                             .con = db)
                              
 mydata <- DBI::dbGetQuery(conn = db,

--- a/R/rmarkdown/income_stmt.Rmd
+++ b/R/rmarkdown/income_stmt.Rmd
@@ -10,7 +10,7 @@ params:
 
 branch <- params$branch
 statement <- glue::glue_sql("SELECT * from financials
-                             WHERE branch == {branch}", 
+                             WHERE branch = {branch}", 
                             .con = db)
                              
 mydata <- DBI::dbGetQuery(conn = db,

--- a/R/rmarkdown/trend.Rmd
+++ b/R/rmarkdown/trend.Rmd
@@ -8,7 +8,7 @@ params:
 branch <- params$branch
 
 statement <- glue::glue_sql("SELECT * from financials
-                             WHERE branch == {branch}", 
+                             WHERE branch = {branch}", 
                             .con = db)
                              
 mydata <- DBI::dbGetQuery(conn = db,


### PR DESCRIPTION
"==" is not a defined operator in SQL for WHERE clauses; it may very well run fine, but you may want to consider converting to "=", which is the defined SQL 'equals' operator